### PR TITLE
fix Cluster typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker run -d --name rundeck-team  -p 4440:4440 \
 
 ```
 
-# Custer Environment
+# Cluster Environment
 
 ## Requirements
 


### PR DESCRIPTION
The README heading for Cluster was Custer. This resolves the typo.